### PR TITLE
doc: rely on cache.Wait() instead of time.Sleep()

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func main() {
 	cache.Set("key", "value", 1)
 	
 	// wait for value to pass through buffers
-	time.Sleep(10 * time.Millisecond)
+	cache.Wait()
 
 	value, found := cache.Get("key")
 	if !found {


### PR DESCRIPTION
👋🏽 hi team

### What
Now that https://github.com/dgraph-io/ristretto/pull/184 has landed, we can update the docs to rely on `cache.Wait()` instead of `time.Sleep()`.

### Rollout Risk: none
Doc only PR, no production code changes